### PR TITLE
Fixed SQL query to parse all $patron's vars

### DIFF
--- a/C4/Utils/DataTables/Members.pm
+++ b/C4/Utils/DataTables/Members.pm
@@ -31,8 +31,10 @@ sub search {
         borrowers.borrowernumber, borrowers.surname, borrowers.firstname,
         borrowers.streetnumber, borrowers.streettype, borrowers.address,
         borrowers.address2, borrowers.city, borrowers.state, borrowers.zipcode,
-        borrowers.country, cardnumber, borrowers.dateexpiry,
+        borrowers.country, cardnumber, borrowers.dateexpiry, borrowers.dateofbirth,
         borrowers.borrowernotes, borrowers.branchcode, borrowers.email,
+        borrowers.emailpro, borrowers.phone, borrowers.phonepro, borrowers.mobile,
+        borrowers.altcontactphone, borrowers.B_phone, borrowers.B_email,
         categories.description AS category_description, categories.category_type,
         branches.branchname";
     my $from = "FROM borrowers


### PR DESCRIPTION
Added to SQL query parsing these fields:
borrowers.dateofbirth, borrowers.emailpro, borrowers.phone, borrowers.phonepro, borrowers.mobile, borrowers.altcontactphone, borrowers.B_phone, borrowers.B_email .. which are alreade later on line 64 associated into e.g. $patron->{mobile} .. useful while attempting to it in templates