### PR TITLE
added setting of gid and g+r for metadump

### DIFF
--- a/debian/scripts/koha-dump
+++ b/debian/scripts/koha-dump
@@ -65,5 +65,7 @@ tar -C / -czf "$metadump" \
     "etc/apache2/sites-enabled/$instancefile" \
     "var/lib/koha/$name" \
     "var/log/koha/$name"
+chown "root:$name-koha" "$metadump"
+chmod g+r "$metadump"
 
 echo "Done."


### PR DESCRIPTION
when using koha-dump, all the files should have the group set to the corresponding koha group