### PR TITLE
Delete useless lines

### DIFF
--- a/installer/data/mysql/ru-RU/mandatory/sample_notices_message_attributes.sql
+++ b/installer/data/mysql/ru-RU/mandatory/sample_notices_message_attributes.sql
@@ -1,5 +1,3 @@
-truncate message_attributes;
-
 insert into `message_attributes`
 (`message_attribute_id`, message_name, `takes_days`)
 values


### PR DESCRIPTION
Deleted line blocks mysql import. Now it is just like in 'en' directory.