### PR TITLE
Added greater than and less than functions

### DIFF
--- a/labels/label-item-search.pl
+++ b/labels/label-item-search.pl
@@ -89,7 +89,7 @@ if ( $op eq "do_search" ) {
                     "acqdate(" . $datefrom . '-)';
             } else {
                 $ccl_query .= ' and ' if $ccl_textbox;
-                $ccl_query .= "acqdate,st-date-normalized,ge=" . $datefrom;
+                $ccl_query .= "acqdate,st-date-normalized,ge>=" . $datefrom;
             }
         }
     }
@@ -103,7 +103,7 @@ if ( $op eq "do_search" ) {
                 $ccl_query .= "acqdate(-" . $dateto . ')';
             } else {
                 $ccl_query .= ' and ' if ( $ccl_textbox || $datefrom );
-                $ccl_query .= "acqdate,st-date-normalized,le=" . $dateto;
+                $ccl_query .= "acqdate,st-date-normalized,le<=" . $dateto;
             }
         }
     }


### PR DESCRIPTION
While searching an item in label creation from a specific date to specific date, after specific date or before specific date is not working. After applying these changes all these functions generate desired results.