### PR TITLE
Auto highlight isbn field for barcode scanner

### DIFF
--- a/koha-tmpl/intranet-tmpl/prog/en/modules/cataloguing/z3950_search.tt
+++ b/koha-tmpl/intranet-tmpl/prog/en/modules/cataloguing/z3950_search.tt
@@ -82,6 +82,7 @@ tr.selected { background-color : #FFFFCC; } tr.selected td { background-color : 
         <li><label for="stdid">Standard ID: </label> <input type="text" id="stdid" name="stdid" value="" /></li>
         <li><a id="resetZ3950Search" href="#"><i class="fa fa-trash"></i> Clear search form</a></li>
         </ol>
+    <script type="text/javascript"> document.getElementById('isbn').focus();; </script>     
     <input type="hidden" name="biblionumber" value="[% biblionumber | html %]" />
     <input type="hidden" name="frameworkcode" value="[% frameworkcode | html %]" />
     </div>


### PR DESCRIPTION
A simple javascript one liner for highlighting the isbn field. Saves a mouse click when scanning with a barcode reader.