### PR TITLE
Prevent unnecessary "operation failed" error

### DIFF
--- a/debian/scripts/koha-restore
+++ b/debian/scripts/koha-restore
@@ -73,7 +73,7 @@ mysqluser="koha_$name"
 mysqlpwd="$( xmlstarlet sel -t -v 'yazgfs/config/pass' /etc/koha/sites/$name/koha-conf.xml )"
 zcat "$sqldump" | mysql --defaults-extra-file=/etc/mysql/koha-common.cnf
 mysql --defaults-extra-file=/etc/mysql/koha-common.cnf <<eof || true
-DROP USER '$mysqluser';
+DROP USER IF EXISTS '$mysqluser';
 eof
 mysql --defaults-extra-file=/etc/mysql/koha-common.cnf << eof || true
 CREATE USER '$mysqluser' IDENTIFIED BY '$mysqlpwd';


### PR DESCRIPTION
Minor paper cut, when restoring I keep getting an error:
`ERROR 1396 (HY000) at line 1: Operation DROP USER failed for 'koha_library'@'%'`

This is already implemented in [`koha-remove`](https://github.com/Koha-Community/Koha/blob/a5a3a330cfc7c7d6c35db13326745dabf8fe0df3/debian/scripts/koha-remove#L69-70) so I'm attempting to add it to `koha-restore` too.