### PR TITLE
Update blocked-fines.inc to correct overdue/payment 500 error

### DIFF
--- a/koha-tmpl/intranet-tmpl/prog/en/includes/blocked-fines.inc
+++ b/koha-tmpl/intranet-tmpl/prog/en/includes/blocked-fines.inc
@@ -1,3 +1,4 @@
+[% USE raw %]
 [% USE Price %]
 [% USE Categories %]
 [% IF NoIssuesCharge and NoIssuesCharge > 0 %]
@@ -8,8 +9,12 @@
            <span class="circ-hlt">Checkouts are BLOCKED because fine balance is OVER THE LIMIT.</span>
         [% END %]
         [% IF CAN_user_updatecharges_remaining_permissions %]
-            <a href="/cgi-bin/koha/members/pay.pl?borrowernumber=[% patron.borrowernumber | uri %]" class="btn btn-default btn-xs" >Make payment</a>
-            <a href="/cgi-bin/koha/members/paycollect.pl?borrowernumber=[% patron.borrowernumber | uri %]" class="btn btn-default btn-xs" >Pay all charges</a>
+            [% IF ( odues ) %]
+                <span class="circ-hlt">Must return ITEMS OVERDUE before payment can be made.</span>
+            [% ELSE %]
+                <a href="/cgi-bin/koha/members/pay.pl?borrowernumber=[% patron.borrowernumber | uri %]" class="btn btn-default btn-xs" >Make payment</a>
+                <a href="/cgi-bin/koha/members/paycollect.pl?borrowernumber=[% patron.borrowernumber | uri %]" class="btn btn-default btn-xs" >Pay all charges</a>
+            [% END %]
         [% END %]
     </li>
 [% END %]


### PR DESCRIPTION
I am not sure that this will do the trick, but I'd like to see something like this implemented so that circ desk personnel are unable to attempt a payment while there are outstanding materials overdue. If you try and process a payment with overdue you get a 500 error. Experienced many staff issues with this.

Unsure if raw contains odue variable.